### PR TITLE
Don't halt execution on .ini fail

### DIFF
--- a/code/source/fileio.cpp
+++ b/code/source/fileio.cpp
@@ -104,7 +104,6 @@ void fileio::initialize(/* const std::string& main_script*/)
 			}
 		}
 	}
-	assert(success);
 
 #if defined(PLATFORM_PC)
 	if(!success)


### PR DESCRIPTION
🔨 If we fail to load a .ini file don't just halt execution